### PR TITLE
Small display case fixes

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -305,7 +305,7 @@ var/global/list/captain_display_cases = list()
 					dump()
 					update_icon()
 				else
-					to_chat(src, "[bicon(src)] <span class='warning'>\The [src] is empty!</span>")
+					to_chat(user, "[bicon(src)] <span class='warning'>\The [src] is empty!</span>")
 		else
 			user.visible_message("[user.name] gently runs his hands over \the [src] in appreciation of its contents.", \
 				"You gently run your hands over \the [src] in appreciation of its contents.", \

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -252,64 +252,51 @@ var/global/list/captain_display_cases = list()
 			new /obj/machinery/constructable_frame/machine_frame(T)
 		qdel(src)
 		return
-	if(user.a_intent == I_HARM)
-		if(locked && !destroyed)
-			src.health -= W.force
-			src.healthcheck()
-			..()
-		else if(!locked)
-			dump()
-			to_chat(user, "<span class='danger'>You smash \the [W] into the delicate electronics at the bottom of the case, and deactivate the hover field.</span>")
-			update_icon()
+	if(locked && !destroyed)
+		src.health -= W.force
+		src.healthcheck()
+		..()
+	else if(!occupant && !(W.flags & ABSTRACT)) //ABSTRACT to stop grabs and the like to be displayed.
+		to_chat(user, "<span class='notice'>You insert \the [W] into \the [src], and it floats as the hoverfield activates.</span>")
+		user.drop_item()
+		W.forceMove(src)
+		occupant=W
+		update_icon()
 	else
-		if(locked)
-			to_chat(user, "<span class='warning'>It's locked, you can't put anything into it.</span>")
-			return
-		if(!occupant && !(W.flags & ABSTRACT)) //ABSTRACT to stop grabs and the like to be displayed.
-			to_chat(user, "<span class='notice'>You insert \the [W] into \the [src], and it floats as the hoverfield activates.</span>")
-			user.drop_item()
-			W.forceMove(src)
-			occupant=W
-			update_icon()
+		to_chat(user, "<span class='danger'>You smash \the [W] into the delicate electronics at the bottom of the case, and deactivate the hover field.</span>")
+		dump()
+		update_icon()
 
 /obj/structure/displaycase/attack_hand(mob/user as mob)
-	if(destroyed || (!locked && user.a_intent == I_HARM))
-		if(occupant)
-			dump()
-			to_chat(user, "<span class='danger'>You smash your fist into the delicate electronics at the bottom of the case, and deactivate the hover field.</span>")
-			src.add_fingerprint(user)
-			update_icon()
-	else
-		if(user.a_intent == I_HARM)
-			user.changeNext_move(CLICK_CD_MELEE)
-			user.do_attack_animation(src)
-			user.visible_message("<span class='danger'>[user.name] kicks \the [src]!</span>", \
-				"<span class='danger'>You kick \the [src]!</span>", \
-				"You hear glass crack.")
-			src.health -= 2
-			healthcheck()
-		else if(!locked)
-			if(ishuman(user))
-				var/mob/living/carbon/human/H = user
-				var/print = H.get_full_print()
-				if(!ue)
-					to_chat(user, "<span class='notice'>Your press your thumb against the fingerprint scanner, registering your identity with the case.</span>")
-					ue = print
-					return
+	if(!locked)
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			var/print = H.get_full_print()
+			if(!ue)
+				to_chat(user, "<span class='notice'>Your press your thumb against the fingerprint scanner, registering your identity with the case.</span>")
+				ue = print
+				return
+			if(occupant)
 				if(ue != print)
-					to_chat(user, "<span class='warning'>Access denied.</span>")
-					return
-
-				if(occupant)
-					to_chat(user, "<span class='notice'>Your press your thumb against the fingerprint scanner, and deactivate the hover field built into the case.</span>")
-					dump()
-					update_icon()
+					to_chat(user, "<span class='danger'>You smash your fist into the delicate electronics at the bottom of the case, and deactivate the hover field.</span>")
+					src.add_fingerprint(user)
 				else
-					to_chat(user, "[bicon(src)] <span class='warning'>\The [src] is empty!</span>")
-		else
-			user.visible_message("[user.name] gently runs his hands over \the [src] in appreciation of its contents.", \
-				"You gently run your hands over \the [src] in appreciation of its contents.", \
-				"You hear someone streaking glass with their greasy hands.")
+					to_chat(user, "<span class='notice'>Your press your thumb against the fingerprint scanner, and deactivate the hover field built into the case.</span>")
+				dump()
+				update_icon()
+			else
+				to_chat(user, "[bicon(src)] <span class='warning'>\The [src] is empty!</span>")
+	else
+		user.changeNext_move(CLICK_CD_MELEE)
+		user.do_attack_animation(src)
+		user.visible_message("<span class='danger'>[user.name] kicks \the [src]!</span>", \
+			"<span class='danger'>You kick \the [src]!</span>", \
+			"You hear glass crack.")
+		src.health -= 2
+		healthcheck()
+		/*user.visible_message("[user.name] gently runs his hands over \the [src] in appreciation of its contents.", \
+			"You gently run your hands over \the [src] in appreciation of its contents.", \
+			"You hear someone streaking glass with their greasy hands.")*/
 
 #undef DISPLAYCASE_FRAME_CIRCUIT
 #undef DISPLAYCASE_FRAME_SCREWDRIVER

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -265,7 +265,7 @@ var/global/list/captain_display_cases = list()
 		if(locked)
 			to_chat(user, "<span class='warning'>It's locked, you can't put anything into it.</span>")
 			return
-		if(!occupant)
+		if(!occupant && !(W.flags & ABSTRACT)) //ABSTRACT to stop grabs and the like to be displayed.
 			to_chat(user, "<span class='notice'>You insert \the [W] into \the [src], and it floats as the hoverfield activates.</span>")
 			user.drop_item()
 			W.forceMove(src)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -256,7 +256,7 @@ var/global/list/captain_display_cases = list()
 		src.health -= W.force
 		src.healthcheck()
 		..()
-	else if(!occupant && !(W.flags & ABSTRACT)) //ABSTRACT to stop grabs and the like to be displayed.
+	else if(!occupant && !(W.flags & (ABSTRACT | NODROP))) //ABSTRACT to stop grabs and the like to be displayed.
 		to_chat(user, "<span class='notice'>You insert \the [W] into \the [src], and it floats as the hoverfield activates.</span>")
 		user.drop_item()
 		W.forceMove(src)


### PR DESCRIPTION
The display case doesn't accept ABSTRACT items anymore, and doesn't try to_chat itself.
Any check for an intent got removed, you attack the case now if you don't use an ID to open it. You can't appreciate it's contents anymore, though.