### PR TITLE
Hanheld module type

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/handheld.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/handheld.dm
@@ -1,0 +1,50 @@
+
+/obj/item/rig_module/handheld
+	name = "mounted device"
+	desc = "Some kind of hardsuit extension."
+	usable = 0
+	selectable = 0
+	toggleable = 1
+	disruptive = 0
+	activate_string = "Deploy"
+	deactivate_string = "Retract"
+
+	var/device_type
+	var/obj/item/device
+
+/obj/item/rig_module/handheld/activate()
+	if(!..())
+		return
+
+	if(!holder.wearer.put_in_hands(device))
+		to_chat(holder.wearer, "<span class='notice'>You need a free hand to hold \the [device].</span>")
+		active = 0
+		return
+
+	to_chat(holder.wearer, "<span class='notice'>You deploy \the [device].</span>")
+
+
+/obj/item/rig_module/handheld/deactivate()
+	if(!..())
+		return
+	if(ismob(device.loc))			//Better check for the holder, instead of assuming the rigwearer has it.
+		var/mob/M = device.loc	//Helps in case the code fails to keep the module in one place, this should still return it.
+		M.unEquip(device, 1)
+
+	device.loc = src
+	to_chat(holder.wearer, "<span class='notice'>You retract \the [device].</span>")
+
+/obj/item/rig_module/handheld/New()
+	..()
+	if(device_type)
+		device = new device_type(src)
+		device.flags |= NODROP //We don't want to drop it while it's active/inhand.
+		activate_string += " [device]"
+		deactivate_string += " [device]"
+
+/obj/item/rig_module/handheld/horn
+	name = "mounted bikehorn"
+	desc = "For tactical honking"
+	interface_name = "mounted bikehorn"
+	interface_desc = "Honks"
+	device_type = /obj/item/weapon/bikehorn

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -613,3 +613,13 @@
 			return 1
 
 	return 0 //Unsupported slot
+
+/mob/living/carbon/human/put_in_l_hand(var/obj/item/W)
+	if(has_organ("l_hand"))
+		return ..()
+	return 0	//Missing the hand, don't equip and signal with the 0
+
+/mob/living/carbon/human/put_in_r_hand(var/obj/item/W)
+	if(has_organ("r_hand"))
+		return ..()
+	return 0	//Missing the hand, don't equip and signal with the 0

--- a/stratus.dme
+++ b/stratus.dme
@@ -1171,6 +1171,7 @@
 #include "code\modules\clothing\spacesuits\rig\rig_wiring.dm"
 #include "code\modules\clothing\spacesuits\rig\modules\combat.dm"
 #include "code\modules\clothing\spacesuits\rig\modules\computer.dm"
+#include "code\modules\clothing\spacesuits\rig\modules\handheld.dm"
 #include "code\modules\clothing\spacesuits\rig\modules\modules.dm"
 #include "code\modules\clothing\spacesuits\rig\modules\ninja.dm"
 #include "code\modules\clothing\spacesuits\rig\modules\utility.dm"


### PR DESCRIPTION
:cl:
adds: A new module type that puts the item into your hand, similar to the water backpacks.
fix: put_in_l/r_hand doesn't put items into missing hands anymore.
/:cl:

Basically just the backbone for the modules, the bikehorn module was made to test it, the fix was needed, else it, like the backpack water tank, would put it in your missing hand. Both can't do that anymore, and since put_in_l/r_hand does have the return that it didn't work already, i think this is how it's supposed to be.