### PR TITLE
Tweaks rigsuit-breaches

### DIFF
--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -92,7 +92,7 @@ var/global/list/breach_burn_descriptors = list(
 	if(!breaches)
 		breaches = list()
 
-	if(damage > 25) return //We don't need to keep tracking it when it's at 250% pressure loss, really.
+	if(damage >= 25) return //We don't need to keep tracking it when it's at 250% pressure loss, really.
 
 	if(!loc) return
 	var/turf/T = get_turf(src)
@@ -125,7 +125,7 @@ var/global/list/breach_burn_descriptors = list(
 		var/datum/breach/B = new()
 		breaches += B
 
-		B.class = min(amount,5)
+		B.class = min(amount,(5-max(damage-20,0))) //We cap the check at 25, this line could overshoot without the calculation if it gets enough dammage in one shot.
 
 		B.damtype = damtype
 		B.update_descriptor()

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -136,6 +136,7 @@
 		if(allowed)
 			chest.allowed = allowed
 		chest.slowdown = offline_slowdown
+		chest.holder = src
 		verbs |= /obj/item/weapon/rig/proc/toggle_chest
 
 	for(var/obj/item/piece in list(gloves,helmet,boots,chest))

--- a/code/modules/clothing/spacesuits/rig/rig_armormod.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_armormod.dm
@@ -1,0 +1,21 @@
+/obj/item/clothing/suit/space/new_rig/calc_breach_damage()
+	..()
+	holder.update_armor()		//New dammage, new armormultiplikator.
+	return damage
+
+/obj/item/weapon/rig/proc/update_armor()
+	var/multi=1					//Multiplicative modification to the armor, maybe add an additive later on
+	if(chest)
+		multi *= (100-chest.damage)/100			//If we have some breaches, lower the armor value.
+
+	//TODO check for other armor mods, likely modules, which need to be coded.
+
+	for(var/obj/item/piece in list(gloves,helmet,boots,chest))
+		if(!istype(piece))			//Do we have the piece
+			continue
+		if(islist(armor))				//Did we even give them some armor, if this is the case, the list should be initialized from New()
+			var/list/L = armor
+			for(var/armortype in L)
+				piece.armor[armortype] = L[armortype]*multi
+
+//Perfect place to also add something like shield modules, or any other hit_reaction modules check.

--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -78,10 +78,10 @@
 	flags_inv =          HIDEJUMPSUIT|HIDETAIL
 	flags =              STOPSPRESSUREDMAGE | THICKMATERIAL | AIRTIGHT | NODROP
 	slowdown = 0
-	//will reach 10 breach damage after 25 laser carbine blasts, 3 revolver hits, or ~1 PTR hit. Completely immune to smg or sts hits.
-	breach_threshold = 38
+	breach_threshold = 20
 	resilience = 0.2
 	can_breach = 1
+	var/obj/item/weapon/rig/holder
 	sprite_sheets = list(
 		"Tajaran" = 'icons/mob/species/tajaran/suit.dmi',
 		"Unathi" = 'icons/mob/species/unathi/suit.dmi'

--- a/stratus.dme
+++ b/stratus.dme
@@ -1165,6 +1165,7 @@
 #include "code\modules\clothing\spacesuits\syndi.dm"
 #include "code\modules\clothing\spacesuits\void.dm"
 #include "code\modules\clothing\spacesuits\rig\rig.dm"
+#include "code\modules\clothing\spacesuits\rig\rig_armormod.dm"
 #include "code\modules\clothing\spacesuits\rig\rig_attackby.dm"
 #include "code\modules\clothing\spacesuits\rig\rig_pieces.dm"
 #include "code\modules\clothing\spacesuits\rig\rig_verbs.dm"


### PR DESCRIPTION
:cl:
tweak:Rigsuits have a lower breaching threshold, now 20.
add: Rigsuit breaches lower the armor value of the whoole rig.
/:cl:

Makes a more precise check to stop a suit from having 25-30 max dammage, now stops at 25 flat. 
Adds an armor modification routine for the whoolerig, as the breach only act on the spacesuit, adds the option for armor modification modules.
Small tweak for the breach dammage, does now happen with more weapons, force of >20 needed.
As you have lower armor values with a breached rig, this especially means a breach can be dangerous with viri, as bio-protection goes down from 100%.
I probably have a merge conflict with my nanoUI fix, going to fix that later.