### PR TITLE
Adds in Vulpkanin heat related things

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -169,6 +169,16 @@
 	base_color = "#CF4D2F"
 	butt_sprite = "vulp"
 
+	cold_level_1 = 235 //Default 260
+	cold_level_2 = 175 //Default 200
+	cold_level_3 = 95 //Default 120
+	cold_env_multiplier = 0.75
+
+	heat_level_1 = 330 //Default 360
+	heat_level_2 = 370 //Default 400
+	heat_level_3 = 430 //Default 460
+	hot_env_multiplier = 1.5
+
 	has_organ = list(
 		"heart" =    /obj/item/organ/internal/heart,
 		"lungs" =    /obj/item/organ/internal/lungs,


### PR DESCRIPTION
As stated in the PR title, this PR adjusts adds in and adjusts a few cold level and heat level values, in the PR all the things changed around are:

- Vulpkanin are now more vulnerable to heat (from 360 to 330 for damage to start)
- Vulpkanin now also take more damage from heat in general such as fires and heated rooms (x1.5 modifier)
- Vulpkanin are more resistant to the cold (from 260 to 235 for damage to start)
- Vulpkanin, as an opposite to heat, take less damage from the cold (x0.75 modifier)

🆑
rscadd: Adds in heat and cold levels for Vulpkanin and differentiates them from the human values.
rscadd: Also adds in heat and cold modifiers, Vulpkanin now take more damage from heat and less from the cold.
/🆑